### PR TITLE
Fix web scrapping for tracks

### DIFF
--- a/entities/Playlists.ts
+++ b/entities/Playlists.ts
@@ -81,7 +81,7 @@ export class Playlists {
         const headers = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"}
         const songHTML = await axios.get(url, {headers}).then((r: any) => r.data)
         const data = JSON.parse(songHTML.match(/(\[{"id")(.*?)(?=\);)/)?.[0])
-        const playlist = data[6].data[0]
+        const playlist = data[7].data[0]
         return playlist as Promise<SoundcloudPlaylistV2>
     }
 }

--- a/entities/Tracks.ts
+++ b/entities/Tracks.ts
@@ -121,7 +121,7 @@ export class Tracks {
         const headers = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"}
         const songHTML = await axios.get(url, {headers}).then((r: any) => r.data)
         const data = JSON.parse(songHTML.match(/(\[{"id")(.*?)(?=\);)/)?.[0])
-        const track = data[6].data[0]
+        const track = data[7].data[0]
         return track as Promise<SoundcloudTrackV2>
     }
 


### PR DESCRIPTION
### Fix web scrapping for tracks

I updated the `getAlt()` methods of `Track` and `Playlist` classes.
There was a bug that caused the method to get information about the creator of the track, not about the track itself.
The same problem was with playlists.

The parsed array has 8 objects. The ones from index 0 to 5 contain not important information, the one with index 6 contains information about the creator of the track and the one with index 7 contains information about the track, which we want.
I changed the index of the returned element to 7 from 6.