### PR TITLE
Add search v2 filter types

### DIFF
--- a/entities/Playlists.ts
+++ b/entities/Playlists.ts
@@ -1,6 +1,6 @@
 import axios from "axios"
 import api from "../API"
-import {SoundcloudPlaylist, SoundcloudPlaylistFilter, SoundcloudPlaylistSearchV2, SoundcloudPlaylistV2, SoundcloudSecretToken} from "../types"
+import {SoundcloudPlaylist, SoundcloudPlaylistFilter, SoundcloudPlaylistSearchV2, SoundcloudPlaylistV2, SoundcloudPlaylistFilterV2, SoundcloudSecretToken} from "../types"
 import {Resolve} from "./index"
 
 export class Playlists {
@@ -19,7 +19,7 @@ export class Playlists {
     /**
      * Searches for playlists using the v2 API.
      */
-    public searchV2 = async (params?: SoundcloudPlaylistFilter) => {
+    public searchV2 = async (params?: SoundcloudPlaylistFilterV2) => {
         const response = await this.api.getV2(`search/playlists`, params)
         return response as Promise<SoundcloudPlaylistSearchV2>
     }

--- a/entities/Tracks.ts
+++ b/entities/Tracks.ts
@@ -1,6 +1,6 @@
 import axios from "axios"
 import api from "../API"
-import {SoundcloudComment, SoundcloudSecretToken, SoundcloudTrack, SoundcloudTrackFilter, SoundcloudTrackSearchV2, SoundcloudTrackV2, SoundcloudUser} from "../types"
+import {SoundcloudComment, SoundcloudSecretToken, SoundcloudTrack, SoundcloudTrackFilter, SoundcloudTrackFilterV2, SoundcloudTrackSearchV2, SoundcloudTrackV2, SoundcloudUser} from "../types"
 import {Resolve} from "./index"
 export class Tracks {
     private readonly resolve = new Resolve(this.api)
@@ -18,7 +18,7 @@ export class Tracks {
     /**
      * Searches for tracks using the v2 API.
      */
-    public searchV2 = async (params?: SoundcloudTrackFilter) => {
+    public searchV2 = async (params?: SoundcloudTrackFilterV2) => {
         const response = await this.api.getV2(`search/tracks`, params)
         return response as Promise<SoundcloudTrackSearchV2>
     }

--- a/entities/Users.ts
+++ b/entities/Users.ts
@@ -1,6 +1,6 @@
 import axios from "axios"
 import api from "../API"
-import {SoundcloudComment, SoundcloudPlaylist, SoundcloudTrack, SoundcloudUser, SoundcloudUserCollection, SoundcloudUserFilter, SoundcloudUserSearchV2,
+import {SoundcloudComment, SoundcloudPlaylist, SoundcloudTrack, SoundcloudUser, SoundcloudUserCollection, SoundcloudUserFilter, SoundcloudUserFilterV2, SoundcloudUserSearchV2,
 SoundcloudUserV2, SoundcloudWebProfile} from "../types"
 import {Resolve} from "./index"
 
@@ -20,7 +20,7 @@ export class Users {
     /**
      * Searches for users using the v2 API.
      */
-    public searchV2 = async (params?: SoundcloudUserFilter) => {
+    public searchV2 = async (params?: SoundcloudUserFilterV2) => {
         const response = await this.api.getV2(`search/users`, params)
         return response as Promise<SoundcloudUserSearchV2>
     }

--- a/types/APITypes.ts
+++ b/types/APITypes.ts
@@ -51,3 +51,9 @@ export interface SoundcloudSearchV2 {
     next_href: string
     query_urn: string
 }
+
+export interface SoundcloudFilterV2 {
+    q: string
+    limit?: number
+    offset?: number
+}

--- a/types/PlaylistTypes.ts
+++ b/types/PlaylistTypes.ts
@@ -1,4 +1,4 @@
-import {SoundcloudLicense, SoundcloudSearchV2, SoundcloudTrack, SoundcloudTrackV2, SoundcloudUserMini, SoundcloudUserV2} from "./index"
+import {SoundcloudLicense, SoundcloudSearchV2, SoundcloudTrack, SoundcloudTrackV2, SoundcloudUserMini, SoundcloudUserV2, SoundcloudFilterV2} from "./index"
 
 export interface SoundcloudPlaylistFilter {
     representation?: "compact" | "id"
@@ -82,4 +82,8 @@ export interface SoundcloudPlaylistV2 {
 
 export interface SoundcloudPlaylistSearchV2 extends SoundcloudSearchV2 {
     collection: SoundcloudPlaylistV2[]
+}
+
+export interface SoundcloudPlaylistFilterV2 extends SoundcloudFilterV2 {
+    "filter.genre_or_tag"?: string
 }

--- a/types/TrackTypes.ts
+++ b/types/TrackTypes.ts
@@ -1,4 +1,4 @@
-import {SoundcloudSearchV2, SoundcloudUserMini, SoundcloudUserV2} from "./index"
+import {SoundcloudSearchV2, SoundcloudUserMini, SoundcloudUserV2, SoundcloudFilterV2} from "./index"
 
 export type SoundcloudLicense =
     | "no-rights-reserved"
@@ -170,4 +170,11 @@ export interface SoundcloudTranscoding {
         mime_type: string
     }
     quality: string
+}
+
+export interface SoundcloudTrackFilterV2 extends SoundcloudFilterV2 {
+    "filter.genre_or_tag"?: string
+    "filter.duration"?: "short" | "medium" | "long" | "epic"
+    "filter.created_at"?: "last_hour" | "last_day" | "last_week" | "last_month" | "last_year"
+    "filter.license"?: "to_modify_commercially" | "to_share" | "to_use_commercially"
 }

--- a/types/UserTypes.ts
+++ b/types/UserTypes.ts
@@ -1,4 +1,4 @@
-import {SoundcloudSearchV2} from "./index"
+import {SoundcloudSearchV2, SoundcloudFilterV2} from "./index"
 export interface SoundcloudUserFilter {
     q?: string
 }
@@ -123,4 +123,8 @@ export interface SoundcloudCreatorSubscription {
     product: {
         id: string
     }
+}
+
+export interface SoundcloudUserFilterV2 extends SoundcloudFilterV2 {
+    "filter.place"?: string
 }


### PR DESCRIPTION
SoundCloud API v2 is undocumented so I have to use `soundcloud.com/search` to find out how it works