### PR TITLE
Add Tracks#getArrayV2 and use it for faster Playlists#fetch

### DIFF
--- a/entities/Playlists.ts
+++ b/entities/Playlists.ts
@@ -12,15 +12,10 @@ export class Playlists {
      * Return playlist with all tracks fetched.
      */
     public fetch = async (playlist: SoundcloudPlaylistV2) => {
-        for (let i = 0; i < playlist.tracks.length; i++) {
-            if (!playlist.tracks[i].title) {
-                try {
-                    playlist.tracks[i] = await this.tracks.getV2(playlist.tracks[i].id)
-                } catch {
-                    // Ignore
-                }
-            }
-        }
+        const unresolvedTracks = playlist.tracks.splice(playlist.tracks.findIndex(t => !t.title)).map(t => t.id)
+        if (unresolvedTracks.length === 0) return playlist
+        playlist.tracks = playlist.tracks.concat(await this.tracks.getArrayV2(unresolvedTracks))
+        console.log(playlist.tracks.length)
         return playlist
     }
 

--- a/entities/Tracks.ts
+++ b/entities/Tracks.ts
@@ -44,6 +44,20 @@ export class Tracks {
     }
 
     /**
+     * Fetches tracks from an array of ID using Soundcloud v2 API.
+     */
+    public getArrayV2 = async (trackIds: number[]) => {
+        if (trackIds.length === 0) return []
+        // Max 50 ids per request => split into chunks of 50 ids
+        const chunks: number[][] = []
+        let i = 0
+        while (i < trackIds.length) chunks.push(trackIds.slice(i, (i += 50)))
+        const response: SoundcloudTrackV2[] = []
+        const tracks = await Promise.all(chunks.map(chunk => this.api.getV2(`/tracks`, { ids: chunk.join(",") })))
+        return response.concat(...tracks)
+    }
+
+    /**
      * @deprecated
      * Fetches all comments on a track.
      */


### PR DESCRIPTION
`Tracks#getArrayV2`: Use v2 `/tracks` endpoint for fetching 50 tracks per request in parallel.
`Playlists#fetch`: Implement `Tracks#getArrayV2` for faster fetching