### PR TITLE
Updating user's webprofile to API V2

### DIFF
--- a/entities/Users.ts
+++ b/entities/Users.ts
@@ -153,12 +153,11 @@ export class Users {
     }
 
     /**
-     * @deprecated
      * Gets all the web profiles on a users sidebar.
      */
     public webProfiles = async (userResolvable: string | number) => {
-        const userID = await this.resolve.get(userResolvable)
-        const response = await this.api.get(`/users/${userID}/web-profiles`)
+        const userID = await this.resolve.getV2(userResolvable)
+        const response = await this.api.getV2(`/users/${userID}/web-profiles`)
         return response as Promise<SoundcloudWebProfile[]>
     }
 

--- a/test/Users.spec.ts
+++ b/test/Users.spec.ts
@@ -64,6 +64,6 @@ describe("Users", async function() {
 
     it("should get a users web profiles", async function() {
         const response = await soundcloud.users.webProfiles("https://soundcloud.com/tenpimusic")
-        // assert(response[0].hasOwnProperty("description"))
+        assert(response[0].hasOwnProperty("url"))
     })
 })

--- a/types/UserTypes.ts
+++ b/types/UserTypes.ts
@@ -99,13 +99,10 @@ export interface SoundcloudUserSearchV2 extends SoundcloudSearchV2 {
 }
 
 export interface SoundcloudWebProfile {
-    kind: "web-profile"
-    id: number
-    service: string
+    network: string
     title: string
     url: string
     username: string | null
-    created_at: string
 }
 
 export interface SoundcloudUserCollection {


### PR DESCRIPTION
After analyzing fetch/XHR calls from user's page it seems there is an endpoint to `https://api-v2.soundcloud.com/users/soundcloud:users:{ID}/web-profiles` to retrieve web-profiles from API V2.

According to this finding, I updated `webProfiles` function to use `getV2` and also updated `SoundcloudWebProfile` to reflect response returned by this endpoint.