### PR TITLE
Fixing url part for `webProfiles` method

### DIFF
--- a/entities/Users.ts
+++ b/entities/Users.ts
@@ -157,7 +157,7 @@ export class Users {
      */
     public webProfiles = async (userResolvable: string | number) => {
         const userID = await this.resolve.getV2(userResolvable)
-        const response = await this.api.getV2(`/users/${userID}/web-profiles`)
+        const response = await this.api.getV2(`/users/soundcloud:users:${userID}/web-profiles`)
         return response as Promise<SoundcloudWebProfile[]>
     }
 


### PR DESCRIPTION
Fixing url part for `webProfiles` method.
Sorry @Tenpi issue in V2 url, need to be prefixed by `soundcloud:users:{ID}`.
Can you un-publish/re-publish version 0.4.8? 